### PR TITLE
More disposing

### DIFF
--- a/percentage/percentage/TrayIcon.cs
+++ b/percentage/percentage/TrayIcon.cs
@@ -44,13 +44,14 @@ namespace percentage
             PowerStatus powerStatus = SystemInformation.PowerStatus;
             batteryPercentage = (powerStatus.BatteryLifePercent * 100).ToString();
 
-            Bitmap bitmap = new Bitmap(DrawText(batteryPercentage, new Font(iconFont, iconFontSize), Color.White, Color.Black));
+            using (Bitmap bitmap = new Bitmap(DrawText(batteryPercentage, new Font(iconFont, iconFontSize), Color.White, Color.Black)))
+            {
+                System.IntPtr intPtr = bitmap.GetHicon();
+                Icon icon = Icon.FromHandle(intPtr);
 
-            System.IntPtr intPtr = bitmap.GetHicon();
-            Icon icon = Icon.FromHandle(intPtr);
-
-            notifyIcon.Icon = icon;
-            notifyIcon.Text = batteryPercentage + "%";
+                notifyIcon.Icon = icon;
+                notifyIcon.Text = batteryPercentage + "%";
+            }
         }
 
         private void menuItem_Click(object sender, EventArgs e)
@@ -62,38 +63,30 @@ namespace percentage
 
         private Image DrawText(String text, Font font, Color textColor, Color backColor)
         {
-            // create a dummy bitmap to get a graphics object
-            Image image = new Bitmap(1, 1);
-            Graphics graphics = Graphics.FromImage(image);
+            var textSize = GetImageSize(text, font);
+            Image image = new Bitmap((int) textSize.Width, (int) textSize.Height);
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                // paint the background
+                graphics.Clear(backColor);
 
-            // measure the string to see how big the image needs to be
-            SizeF textSize = graphics.MeasureString(text, font);
-
-            // free up the dummy image and old graphics object
-            image.Dispose();
-            graphics.Dispose();
-
-            // create a new image of the right size
-            image = new Bitmap((int) textSize.Width, (int) textSize.Height);
-
-            graphics = Graphics.FromImage(image);
-
-            // paint the background
-            graphics.Clear(backColor);
-
-            // create a brush for the text
-            Brush textBrush = new SolidBrush(textColor);
-
-            graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
-
-            graphics.DrawString(text, font, textBrush, 0, 0);
-
-            graphics.Save();
-
-            textBrush.Dispose();
-            graphics.Dispose();
+                // create a brush for the text
+                using (Brush textBrush = new SolidBrush(textColor))
+                {
+                    graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+                    graphics.DrawString(text, font, textBrush, 0, 0);
+                    graphics.Save();
+                }
+            }
 
             return image;
+        }
+
+        private static SizeF GetImageSize(string text, Font font)
+        {
+            using (Image image = new Bitmap(1, 1))
+            using (Graphics graphics = Graphics.FromImage(image))
+                return graphics.MeasureString(text, font);
         }
     }
 }

--- a/percentage/percentage/TrayIcon.cs
+++ b/percentage/percentage/TrayIcon.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace percentage
 {
     class TrayIcon
     {
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        static extern bool DestroyIcon(IntPtr handle);
+
         private const string iconFont = "Segoe UI";
         private const int iconFontSize = 14;
 
@@ -47,10 +51,18 @@ namespace percentage
             using (Bitmap bitmap = new Bitmap(DrawText(batteryPercentage, new Font(iconFont, iconFontSize), Color.White, Color.Black)))
             {
                 System.IntPtr intPtr = bitmap.GetHicon();
-                Icon icon = Icon.FromHandle(intPtr);
-
-                notifyIcon.Icon = icon;
-                notifyIcon.Text = batteryPercentage + "%";
+                try
+                {
+                    using (Icon icon = Icon.FromHandle(intPtr))
+                    {
+                        notifyIcon.Icon = icon;
+                        notifyIcon.Text = batteryPercentage + "%";
+                    }
+                }
+                finally
+                {
+                    DestroyIcon(intPtr);
+                }
             }
         }
 

--- a/percentage/percentage/TrayIcon.cs
+++ b/percentage/percentage/TrayIcon.cs
@@ -55,6 +55,8 @@ namespace percentage
 
         private void menuItem_Click(object sender, EventArgs e)
         {
+            notifyIcon.Visible = false;
+            notifyIcon.Dispose();
             Application.Exit();
         }
 


### PR DESCRIPTION
There were two items not being disposed of that could be in the `timer_tick` method: when setting an `Icon` property it's actually copied rather than set directly (not intuitive at all).  The other is that the `IntPtr` returned by `GetHIcon` has to manually freed by `DestroyIcon`.

I migrated the part about getting the size to its own method so that `using` statements could be used more easily, which ensures items get disposed of even if there's an error rather than a manual `Dispose()` call.