### PR TITLE
Show More Information in the Icon, Tooltip, and Context Menu

### DIFF
--- a/percentage/percentage/TrayIcon.cs
+++ b/percentage/percentage/TrayIcon.cs
@@ -15,19 +15,24 @@ namespace percentage
 
         private string batteryPercentage;
         private NotifyIcon notifyIcon;
+        private MenuItem descriptionMenuItem;
 
         public TrayIcon()
         {
             ContextMenu contextMenu = new ContextMenu();
             MenuItem menuItem = new MenuItem();
+            descriptionMenuItem = new MenuItem();
 
             notifyIcon = new NotifyIcon();
 
             // initialize contextMenu
-            contextMenu.MenuItems.AddRange(new MenuItem[] { menuItem });
+            contextMenu.MenuItems.AddRange(new MenuItem[] { descriptionMenuItem, menuItem });
+
+            // initialize descriptionMenuItem
+            descriptionMenuItem.Text = "";
+            descriptionMenuItem.Enabled = false;
 
             // initialize menuItem
-            menuItem.Index = 0;
             menuItem.Text = "E&xit";
             menuItem.Click += new System.EventHandler(menuItem_Click);
 
@@ -113,6 +118,8 @@ namespace percentage
                         }
                         notifyIcon.Icon = icon;
                         notifyIcon.Text = description;
+
+                        descriptionMenuItem.Text = description;
                     }
                 }
                 finally


### PR DESCRIPTION
Updated the icon to use green text while charging and red text when the battery level is critical.
Updated the tooltip to show time remaining when on battery and information about the charge state when plugged in.
Updated the context menu to show the same information as the tooltip.